### PR TITLE
use space provided in the scope of the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $tokenClient = new TokenClient('YOUR-CLIENT-ID', 'YOUR-CLIENT-SECRET');
 $tokenCache = new TokenCache($tokenClient);
 $client = new LemonMarketsClient($tokenCache);
 
-$placedOrder = $client->placeOrder($spaceUuid, new PlaceOrderCommand(
+$placedOrder = $client->placeOrder(new PlaceOrderCommand(
     isin: 'US29786A1060',
     validUntil: strval(time() + 3600),
     side: PlaceOrderCommand::SIDE_BUY,
@@ -62,7 +62,7 @@ $placedOrder = $client->placeOrder($spaceUuid, new PlaceOrderCommand(
 ));
 print_r($placedOrder);
 
-$activation = $client->activateOrder($spaceUuid, $placedOrder->uuid);
+$activation = $client->activateOrder($placedOrder->uuid);
 print_r($activation);
 ```
 

--- a/src/LemonMarketsClient.php
+++ b/src/LemonMarketsClient.php
@@ -40,36 +40,41 @@ class LemonMarketsClient extends AbstractClient
         return $this->deserialize($body, Spaces::class);
     }
 
-    public function getSpace(UuidInterface $spaceUuid): Space
+    public function getSpace(): Space
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('get', sprintf('/rest/v1/spaces/%s', $spaceUuid));
 
         return $this->deserialize($body, Space::class);
     }
 
-    public function getSpaceState(UuidInterface $spaceUuid): SpaceState
+    public function getSpaceState(): SpaceState
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('get', sprintf('/rest/v1/spaces/%s/state', $spaceUuid));
 
         return $this->deserialize($body, SpaceState::class);
     }
 
-    public function getOrders(UuidInterface $spaceUuid, array $params = []): Orders
+    public function getOrders(array $params = []): Orders
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('get', sprintf('/rest/v1/spaces/%s/orders', $spaceUuid), ['query' => $params]);
 
         return $this->deserialize($body, Orders::class);
     }
 
-    public function getOrder(UuidInterface $spaceUuid, UuidInterface $orderUuid): Order
+    public function getOrder(UuidInterface $orderUuid): Order
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('get', sprintf('/rest/v1/spaces/%s/orders/%s', $spaceUuid, $orderUuid));
 
         return $this->deserialize($body, Order::class);
     }
 
-    public function placeOrder(UuidInterface $spaceUuid, PlaceOrderCommand $command): PlacedOrder
+    public function placeOrder(PlaceOrderCommand $command): PlacedOrder
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('post', sprintf('/rest/v1/spaces/%s/orders', $spaceUuid), [
             'form_params' => $command->toArray(),
         ]);
@@ -77,15 +82,18 @@ class LemonMarketsClient extends AbstractClient
         return $this->deserialize($body, PlacedOrder::class);
     }
 
-    public function activateOrder(UuidInterface $spaceUuid, UuidInterface $orderUuid): OrderActivation
+    public function activateOrder(UuidInterface $orderUuid): OrderActivation
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('put', sprintf('/rest/v1/spaces/%s/orders/%s/activate', $spaceUuid, $orderUuid));
 
         return $this->deserialize($body, OrderActivation::class);
     }
 
-    public function deleteOrder(UuidInterface $spaceUuid, UuidInterface $orderUuid): void
+    public function deleteOrder(UuidInterface $orderUuid): void
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
+
         try {
             $this->request('delete', sprintf('/rest/v1/spaces/%s/orders/%s', $spaceUuid, $orderUuid));
         } catch (ClientException $ex) {
@@ -95,15 +103,17 @@ class LemonMarketsClient extends AbstractClient
         }
     }
 
-    public function getPortfolio(UuidInterface $spaceUuid): Portfolio
+    public function getPortfolio(): Portfolio
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('get', sprintf('/rest/v1/spaces/%s/portfolio', $spaceUuid));
 
         return $this->deserialize($body, Portfolio::class);
     }
 
-    public function getTransactions(UuidInterface $spaceUuid, array $params = []): Transactions
+    public function getTransactions(array $params = []): Transactions
     {
+        $spaceUuid = $this->tokenCache->getToken()->spaceUuid;
         $body = $this->request('get', sprintf('/rest/v1/spaces/%s/transactions', $spaceUuid), ['query' => $params]);
 
         return $this->deserialize($body, Transactions::class);

--- a/src/Model/Response/AccessToken.php
+++ b/src/Model/Response/AccessToken.php
@@ -3,6 +3,11 @@ declare(strict_types=1);
 
 namespace LemonMarketsClient\Model\Response;
 
+use InvalidArgumentException;
+use JMS\Serializer\Annotation\PostDeserialize;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
 class AccessToken
 {
     public string $accessToken;
@@ -12,4 +17,16 @@ class AccessToken
     public string $scope;
 
     public string $tokenType;
+
+    public UuidInterface $spaceUuid;
+
+    #[PostDeserialize]
+    public function initSpaceUuid()
+    {
+        if (!preg_match('#space:([A-F0-9\-]{36})#i', $this->scope, $matches)) {
+            throw new InvalidArgumentException('Missing space in scope of the access token.');
+        }
+
+        $this->spaceUuid = Uuid::fromString($matches[1]);
+    }
 }

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace LemonMarketsClient\Model\Response;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class AccessTokenTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function initSpaceUuid_throws_exception_when_scope_is_empty()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $subject = new AccessToken();
+        $subject->scope = '';
+
+        $subject->initSpaceUuid();
+    }
+
+    /**
+     * @test
+     */
+    public function initSpaceUuid_throws_exception_when_scope_contains_invalid_uuid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $subject = new AccessToken();
+        $subject->scope = 'space:this-is-invalid';
+
+        $subject->initSpaceUuid();
+    }
+
+    /**
+     * @test
+     */
+    public function initSpaceUuid_assign_spaceUuid_from_scope()
+    {
+        $spaceUuid = Uuid::fromString('f28a807d-ea5f-4235-9b75-dff62e3dd529');
+        $subject = new AccessToken();
+        $subject->scope = sprintf('portfolio:read space:%s order:write', $spaceUuid);
+
+        $subject->initSpaceUuid();
+
+        $this->assertEquals($spaceUuid, $subject->spaceUuid);
+    }
+}

--- a/tests/LemonMarketsClientTest.php
+++ b/tests/LemonMarketsClientTest.php
@@ -18,7 +18,9 @@ use Ramsey\Uuid\Uuid;
 
 class LemonMarketsClientTest extends TestCase
 {
-    private static string $accessToken = '0a1349be-2d87-4540-a2b6-e3e4c21b5adb';
+    private static string $accessToken = 'some-access-token';
+
+    private static string $spaceUuid = '13c64177-9990-4721-a5be-6086c497a5ad';
 
     private LemonMarketsClient $subject;
 
@@ -60,13 +62,12 @@ class LemonMarketsClientTest extends TestCase
      */
     public function getSpace_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $response = $this->mockResponse('get-space.json');
 
-        $spaces = $this->subject->getSpace($spaceUuid);
+        $spaces = $this->subject->getSpace();
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid, $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid, $request->getUri());
         $this->assertEquals('GET', $request->getMethod());
         $this->compareJson($spaces, $response);
     }
@@ -76,13 +77,12 @@ class LemonMarketsClientTest extends TestCase
      */
     public function getSpaceState_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $response = $this->mockResponse('get-space-state.json');
 
-        $spaceState = $this->subject->getSpaceState($spaceUuid);
+        $spaceState = $this->subject->getSpaceState();
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/state', $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/state', $request->getUri());
         $this->assertEquals('GET', $request->getMethod());
         $this->compareJson($spaceState, $response);
     }
@@ -92,13 +92,12 @@ class LemonMarketsClientTest extends TestCase
      */
     public function getOrders_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $response = $this->mockResponse('get-orders.json');
 
-        $orders = $this->subject->getOrders($spaceUuid, ['side' => 'buy']);
+        $orders = $this->subject->getOrders(['side' => 'buy']);
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/orders?side=buy', $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/orders?side=buy', $request->getUri());
         $this->assertEquals('GET', $request->getMethod());
         $this->compareJson($orders, $response);
     }
@@ -108,14 +107,13 @@ class LemonMarketsClientTest extends TestCase
      */
     public function getOrder_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $orderUuid = Uuid::uuid4();
         $response = $this->mockResponse('get-order.json');
 
-        $order = $this->subject->getOrder($spaceUuid, $orderUuid);
+        $order = $this->subject->getOrder($orderUuid);
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/orders/' . $orderUuid, $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/orders/' . $orderUuid, $request->getUri());
         $this->assertEquals('GET', $request->getMethod());
         $this->compareJson($order, $response);
     }
@@ -125,7 +123,6 @@ class LemonMarketsClientTest extends TestCase
      */
     public function placeOrder_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $response = $this->mockResponse('place-order.json');
         $command = new PlaceOrderCommand(
             isin: 'US29786A1060',
@@ -134,10 +131,10 @@ class LemonMarketsClientTest extends TestCase
             quantity: 1
         );
 
-        $order = $this->subject->placeOrder($spaceUuid, $command);
+        $order = $this->subject->placeOrder($command);
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/orders', $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/orders', $request->getUri());
         $this->assertEquals('POST', $request->getMethod());
         $this->compareJson($order, $response);
     }
@@ -147,14 +144,13 @@ class LemonMarketsClientTest extends TestCase
      */
     public function activateOrder_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $orderUuid = Uuid::uuid4();
         $response = $this->mockResponse('activate-order.json');
 
-        $activation = $this->subject->activateOrder($spaceUuid, $orderUuid);
+        $activation = $this->subject->activateOrder($orderUuid);
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/orders/' . $orderUuid . '/activate', $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/orders/' . $orderUuid . '/activate', $request->getUri());
         $this->assertEquals('PUT', $request->getMethod());
         $this->compareJson($activation, $response);
     }
@@ -164,14 +160,13 @@ class LemonMarketsClientTest extends TestCase
      */
     public function deleteOrder_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $orderUuid = Uuid::uuid4();
         $this->mock->append(new Response(204));
 
-        $this->subject->deleteOrder($spaceUuid, $orderUuid);
+        $this->subject->deleteOrder($orderUuid);
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/orders/' . $orderUuid, $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/orders/' . $orderUuid, $request->getUri());
         $this->assertEquals('DELETE', $request->getMethod());
     }
 
@@ -180,13 +175,12 @@ class LemonMarketsClientTest extends TestCase
      */
     public function getPortfolio_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $response = $this->mockResponse('get-portfolio.json');
 
-        $portfolio = $this->subject->getPortfolio($spaceUuid);
+        $portfolio = $this->subject->getPortfolio();
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/portfolio', $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/portfolio', $request->getUri());
         $this->assertEquals('GET', $request->getMethod());
         $this->compareJson($portfolio, $response);
     }
@@ -196,13 +190,12 @@ class LemonMarketsClientTest extends TestCase
      */
     public function getTransactions_sends_correct_request_and_decodes_response()
     {
-        $spaceUuid = Uuid::uuid4();
         $response = $this->mockResponse('get-transactions.json');
 
-        $transactions = $this->subject->getTransactions($spaceUuid, ['limit' => 50]);
+        $transactions = $this->subject->getTransactions(['limit' => 50]);
 
         $request = $this->getSentRequest();
-        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . $spaceUuid . '/transactions?limit=50', $request->getUri());
+        $this->assertEquals('https://api.example.org/rest/v1/spaces/' . self::$spaceUuid . '/transactions?limit=50', $request->getUri());
         $this->assertEquals('GET', $request->getMethod());
         $this->compareJson($transactions, $response);
     }
@@ -275,7 +268,9 @@ class LemonMarketsClientTest extends TestCase
     private function mockTokenCache(): TokenCache
     {
         $token = new AccessToken();
-        $token->accessToken = 'some-access-token';
+        $token->accessToken = self::$accessToken;
+        $token->scope = sprintf('portfolio:read space:%s', self::$spaceUuid);
+        $token->initSpaceUuid();
 
         $tokenCache = $this->createMock(TokenCache::class);
         $tokenCache->expects($this->any())

--- a/tests/TokenClientTest.php
+++ b/tests/TokenClientTest.php
@@ -34,7 +34,7 @@ class TokenClientTest extends TestCase
      */
     public function authenticate_sends_correct_request()
     {
-        $this->mock->append(new Response(200, [], '{}'));
+        $this->mock->append(new Response(200, [], $this->getAccessTokenAsJson()));
 
         $this->subject->authenticate();
 
@@ -51,23 +51,28 @@ class TokenClientTest extends TestCase
     /**
      * @test
      */
-    public function getSpaces_sends_correct_request()
+    public function authenticate_decodes_response()
     {
-        $body = <<<BODY
-            {
-             "access_token": "some-access-token",
-             "expires_in": 2591999,
-             "scope": "some-scope",
-             "token_type": "bearer"
-            }
-        BODY;
-
-        $this->mock->append(new Response(200, [], $body));
+        $this->mock->append(new Response(200, [], $this->getAccessTokenAsJson()));
 
         $token = $this->subject->authenticate();
+
         $this->assertEquals('some-access-token', $token->accessToken);
         $this->assertEquals(2591999, $token->expiresIn);
-        $this->assertEquals('some-scope', $token->scope);
+        $this->assertEquals('portfolio:read space:f28a807d-ea5f-4235-9b75-dff62e3dd529', $token->scope);
         $this->assertEquals('bearer', $token->tokenType);
+        $this->assertEquals('f28a807d-ea5f-4235-9b75-dff62e3dd529', $token->spaceUuid);
+    }
+
+    private function getAccessTokenAsJson(): string
+    {
+        return trim('
+            {
+                "access_token": "some-access-token",
+                "expires_in": 2591999,
+                "scope": "portfolio:read space:f28a807d-ea5f-4235-9b75-dff62e3dd529",
+                "token_type": "bearer"
+            }
+        ');
     }
 }


### PR DESCRIPTION
In order to make the API of the client easier to use the uuid of the space can be extracted from the scope of the requested access token. This allows us to remove the spaceUuid as first argument from all methods related to a space.